### PR TITLE
Fix global error

### DIFF
--- a/run.py
+++ b/run.py
@@ -36,6 +36,7 @@ def returnBal(username):
 
 
 def process(message, username, chatid):
+    global active_users
     message = message.split(" ")
     for i in range(message.count(' ')):
         message.remove(' ')
@@ -118,7 +119,6 @@ def process(message, username, chatid):
     elif "/active" in message:
         sendMsg("Current active : %d shibes" % (len(getActive(chatid, active_users, current_time))), chatid)
     else:
-        global active_users
         try:
             active_users[chatid][username] = time.time()
         except KeyError:


### PR DESCRIPTION
I was able to resolve the error being thrown [here](https://github.com/peakshift/telegram-dogecoin/pull/10#issuecomment-410803616). 

It turns out that when we added `active_users` as an argument for the `def getActive()` function, this resulted in the variable `active_users` being called within the `def process()` function before the global declaration of that `active_users` variable on line 121. According to [Python Docs](https://docs.python.org/3/reference/simple_stmts.html#the-global-statement), global declarations should be _the first instance of a variable within a function_ so to fix this I simply moved line 121 to the top of the `def process()` function.

Glad we were finally able to figure this out!